### PR TITLE
Update RemoteHostUrl in appsettings.json

### DIFF
--- a/src/UI/Krafter.UI.Web.Client/wwwroot/appsettings.json
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/appsettings.json
@@ -5,7 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "RemoteHostUrl": "{YOUR_BACKEND_HOST}",
+  "RemoteHostUrl": "api.getkrafter.dev",
   "Authentication": {
     "Google": {
       "ClientId": "{YOUR_GOOGLE_CLIENT_ID}"


### PR DESCRIPTION
Replaced the placeholder `{YOUR_BACKEND_HOST}` with the actual backend API URL `api.getkrafter.dev` to ensure the application is correctly configured to communicate with the backend service.