### PR TITLE
Refactor rootDomain calculation in TenantIdentifier

### DIFF
--- a/src/UI/Krafter.UI.Web.Client/Infrastructure/Http/TenantIdentifier.cs
+++ b/src/UI/Krafter.UI.Web.Client/Infrastructure/Http/TenantIdentifier.cs
@@ -49,9 +49,9 @@ public class TenantIdentifier(IServiceProvider serviceProvider,IConfiguration co
             var strings = host.Split('.'); tenantIdentifier = strings.Length > 2 ? strings[0] : "api";
             remoteHostUrl = $"https://{tenantIdentifier}.{configuration["RemoteHostUrl"]}";
             clientBaseAddress = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
-
         }
-        var rootDomain=host.Replace($"{tenantIdentifier}.", "");
+        var prefix = tenantIdentifier + ".";
+        var rootDomain = host.Substring(prefix.Length);
         return (tenantIdentifier, remoteHostUrl, rootDomain, clientBaseAddress);
     } 
 }


### PR DESCRIPTION
Replaced the use of the Replace method with a Substring-based approach to calculate the rootDomain. This change introduces a prefix string (tenantIdentifier + ".") to ensure the rootDomain is derived accurately and avoids potential issues with unintended replacements. Improves clarity and correctness of the logic.