### PR TITLE
Add Scalar package and support multi-arch containers

### DIFF
--- a/src/Backend/Backend.csproj
+++ b/src/Backend/Backend.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<!-- Background Jobs -->
-		
+
 		<PackageReference Include="Scalar.AspNetCore.Microsoft" Version="2.10.3" />
 		<PackageReference Include="TickerQ" Version="2.5.3" />
 		<PackageReference Include="TickerQ.Dashboard" Version="2.5.3" />
@@ -40,13 +40,13 @@
 
 		<!-- API & Swagger -->
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-		
+
 
 		<!-- Validation -->
 		<PackageReference Include="FluentValidation" Version="12.1.0" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.0" />
 		<PackageReference Include="ForEvolve.FluentValidation.AspNetCore.Http" Version="1.0.26" />
-		
+
 
 		<!-- External Integrations -->
 		<PackageReference Include="Refit" Version="8.0.0" />
@@ -67,7 +67,7 @@
 	<!-- Docker Container Configuration -->
 	<PropertyGroup>
 		<ContainerFamily>noble</ContainerFamily>
-		<ContainerRuntimeIdentifier>linux-arm64</ContainerRuntimeIdentifier>
+		<ContainerRuntimeIdentifiers>linux-x64;linux-arm64</ContainerRuntimeIdentifiers>
 		<ContainerRepository>ghcr.io/aditikraft/krafter.api</ContainerRepository>
 		<ContainerRegistry>ghcr.io</ContainerRegistry>
 	</PropertyGroup>

--- a/src/UI/Krafter.UI.Web/Krafter.UI.Web.csproj
+++ b/src/UI/Krafter.UI.Web/Krafter.UI.Web.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <PropertyGroup>
     <ContainerFamily>noble</ContainerFamily>
-    <ContainerRuntimeIdentifier>linux-arm64</ContainerRuntimeIdentifier>
+	<ContainerRuntimeIdentifiers>linux-x64;linux-arm64</ContainerRuntimeIdentifiers>
     <ContainerRepository>ghcr.io/aditikraft/krafter.ui.web</ContainerRepository>
     <ContainerRegistry>ghcr.io</ContainerRegistry>
   </PropertyGroup>


### PR DESCRIPTION
Updated `<ContainerRuntimeIdentifier>` to `<ContainerRuntimeIdentifiers>` in both `Backend.csproj` and `Krafter.UI.Web.csproj` to support `linux-x64` and `linux-arm64` architectures, enabling multi-arch container builds.

Ensured consistency across projects for container runtime settings.