### PR TITLE
Update solution file reference in parameters.json

### DIFF
--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./build.schema.json",
-  "Solution": "Krafter.sln"
+  "Solution": "Krafter.slnx"
 }


### PR DESCRIPTION
The `Solution` property in `parameters.json` was updated to reference `Krafter.slnx` instead of `Krafter.sln`. This change may reflect a migration to a new solution file format or an updated project structure.