### PR TITLE
Update brand colors to deep tech purple & unify SVG/CSS

### DIFF
--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -10,7 +10,19 @@
       .data { fill: #f3e5f5; stroke: #9c27b0; }
       .infra { fill: #e8f5e9; stroke: #4caf50; }
     </style>
-  </defs>
+  
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
   
   <text x="500" y="30" class="title" text-anchor="middle">Krafter Architecture</text>
   
@@ -101,7 +113,19 @@
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
     </marker>
-  </defs>
+  
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
   
   <line x1="250" y1="240" x2="250" y2="270" stroke="#666" stroke-width="2" marker-end="url(#arrowhead)"/>
   <text x="260" y="260" class="text">HTTPS/SignalR</text>

--- a/docs/dependencies.svg
+++ b/docs/dependencies.svg
@@ -10,7 +10,19 @@
       .ui { fill: #e7f3ff; stroke: #0066cc; }
       .build { fill: #ffebee; stroke: #f44336; }
     </style>
-  </defs>
+  
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
   
   <text x="500" y="30" class="title" text-anchor="middle">Project Dependencies</text>
   
@@ -89,7 +101,19 @@
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
     </marker>
-  </defs>
+  
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
   
   <line x1="300" y1="130" x2="350" y2="130" stroke="#666" stroke-width="2" stroke-dasharray="5,5"/>
   <text x="310" y="125" class="text">Orchestrates</text>

--- a/docs/krafter-logo.svg
+++ b/docs/krafter-logo.svg
@@ -1,12 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" width="1280" height="640">
 	<defs>
 		<style>
-			.k-nav { fill: #111111; }
-			.k-grn { fill: #33cc77; }
-			.brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-			.tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+			.k-nav { fill: #0F172A; }
+			.k-grn { fill: url(#deepTechGradient); filter: url(#glow); }
+			.brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+			.tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
 		</style>
-	</defs>
+	
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
 	<rect x="0" y="0" width="640" height="320" fill="#333333" />
 	<g transform="translate(142.5, 70)">
 		<g id="icon">

--- a/docs/krafter-spinner.svg
+++ b/docs/krafter-spinner.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="120" height="120">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: url(#deepTechGradient); filter: url(#glow); }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive
@@ -64,7 +64,19 @@
         <feMergeNode in="SourceGraphic" />
       </feMerge>
     </filter>
-  </defs>
+  
+        <linearGradient id="deepTechGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#764AF1" />
+            <stop offset="100%" stop-color="#06B6D4" />
+        </linearGradient>
+        <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+            <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
+</defs>
 
   <!-- Centered modular-K icon reduced for spinner -->
   <g id="spinner" class="soft-shadow" transform="translate(0,0)">

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/app.css
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/app.css
@@ -1,19 +1,111 @@
-html, body {
+/* ==========================================================================
+   Deep Tech Color Palette - CSS Custom Properties
+   ========================================================================== */
+:root {
+    /* ========== Core Brand Colors (Unified with Logo) ========== */
+    --color-primary: #764AF1;
+    /* Logo Purple (Main Brand) */
+    --color-primary-hover: #8B5CF6;
+    /* Interactive states */
+    --color-primary-active: #5B2DCF;
+    /* Active states */
+    --color-primary-dark: #3D1A99;
+    /* Deep Violet (Dark Anchor) */
+    --color-primary-light: #A78BFA;
+    /* Light Purple */
+
+    /* ========== Secondary Accent Colors ========== */
+    --color-accent-cyan: #06B6D4;
+    /* Neon Cyan (AI Highlight) */
+    --color-accent-cyan-hover: #22D3EE;
+    /* Cyan Hover */
+    --color-accent-pink: #EC4899;
+    /* Hot Pink (CTAs) */
+    --color-accent-pink-hover: #F472B6;
+    /* Pink Hover */
+
+    /* ========== Dark Theme Background ========== */
+    --color-bg-primary: #0F172A;
+    /* Slate 900 */
+    --color-bg-secondary: #1E293B;
+    /* Slate 800 */
+    --color-bg-tertiary: #020617;
+    /* Slate 950 (Absolute Deep) */
+
+    /* ========== Surface Colors (Glassmorphism) ========== */
+    --color-surface: rgba(30, 41, 59, 0.7);
+    /* Cards, Panels */
+    --color-surface-hover: rgba(51, 65, 85, 0.8);
+    /* Hover State */
+    --color-surface-active: rgba(71, 85, 105, 0.9);
+    /* Active State */
+    --color-surface-border: rgba(255, 255, 255, 0.08);
+    /* Glass Borders */
+
+    /* ========== Text Colors ========== */
+    --color-text-primary: #F8FAFC;
+    /* Slate 50 */
+    --color-text-secondary: #CBD5E1;
+    /* Slate 300 */
+    --color-text-tertiary: #94A3B8;
+    /* Slate 400 */
+    --color-text-muted: #64748B;
+    /* Slate 500 */
+
+    /* ========== Status Colors ========== */
+    --color-success: #10B981;
+    /* Emerald */
+    --color-warning: #F59E0B;
+    /* Amber */
+    --color-error: #EF4444;
+    /* Red */
+    --color-info: #3B82F6;
+    /* Blue */
+
+    /* ========== Borders & Dividers ========== */
+    --color-border: rgba(255, 255, 255, 0.08);
+    /* Default Border */
+    --color-border-light: rgba(255, 255, 255, 0.12);
+    /* Highlighted Border */
+    --color-divider: rgba(255, 255, 255, 0.06);
+    /* Separators */
+
+    /* ========== Code Syntax Colors ========== */
+    --color-code-keyword: #C084FC;
+    /* Keywords */
+    --color-code-class: #F472B6;
+    /* Class Names */
+    --color-code-type: #22D3EE;
+    /* Type Names */
+    --color-code-string: #34D399;
+    /* Strings */
+}
+
+/* ==========================================================================
+   Base Styles
+   ========================================================================== */
+html,
+body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-a, .btn-link {
-    color: #006bb7;
+a,
+.btn-link {
+    color: var(--color-primary);
 }
 
 .btn-primary {
-    color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
+    color: var(--color-text-primary);
+    background-color: var(--color-primary);
+    border-color: var(--color-primary-hover);
 }
 
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-    box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+.btn:focus,
+.btn:active:focus,
+.btn-link.nav-link:focus,
+.form-control:focus,
+.form-check-input:focus {
+    box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--color-primary);
 }
 
 .content {
@@ -25,29 +117,29 @@ h1:focus {
 }
 
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid #26b050;
+    outline: 1px solid var(--color-success);
 }
 
 .invalid {
-    outline: 1px solid #e50000;
+    outline: 1px solid var(--color-error);
 }
 
 .validation-message {
-    color: #e50000;
+    color: var(--color-error);
 }
 
 .blazor-error-boundary {
-    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, #b32121;
+    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3LjgyOSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N7MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, var(--color-error);
     padding: 1rem 1rem 1rem 3.7rem;
     color: white;
 }
 
-    .blazor-error-boundary::after {
-        content: "An error has occurred."
-    }
+.blazor-error-boundary::after {
+    content: "An error has occurred."
+}
 
 .darker-border-checkbox.form-check-input {
-    border-color: #929292;
+    border-color: var(--color-border-light);
 }
 
 .app-loading-container {
@@ -62,12 +154,14 @@ h1:focus {
     width: 100%;
     display: flex;
     flex-wrap: wrap;
-    margin: -0.5rem; /* Compensate for item padding */
+    margin: -0.5rem;
+    /* Compensate for item padding */
 }
 
 .kr-bit-infinite-scroll-item {
     padding: 0.5rem;
-    width: 25%; /* 4 items per row */
+    width: 25%;
+    /* 4 items per row */
     box-sizing: border-box;
 }
 
@@ -117,4 +211,5 @@ h1:focus {
     padding: 1rem 0;
     clear: both;
 }
+
 /* End of Infinite Scroll Grid */

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-l.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-l.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="160" height="160">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: #764AF1; }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-m.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-m.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="120" height="120">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: #764AF1; }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-s.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-s.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="80" height="80">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: #764AF1; }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-xl.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-xl.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="240" height="240">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: #764AF1; }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-xs.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/loading-indicators/loading-indicator-xs.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120" width="48" height="48">
   <defs>
     <style>
-      .k-nav { fill: #13294b; }
-      .k-grn { fill: #33cc77; }
+      .k-nav { fill: #0F172A; }
+      .k-grn { fill: #764AF1; }
 
       /* Modern animation system using CSS keyframes. Each tile uses CSS variables
          to set its initial offset and rotation so we can create a cohesive

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-l-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-l-dark.svg
@@ -1,12 +1,18 @@
-﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="120" preserveAspectRatio="xMinYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="120" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #111111; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
         </style>
     </defs>
+
+    
+
+    
+    
 
     <g id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-l-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-l-light.svg
@@ -1,12 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="120" preserveAspectRatio="xMinYMid meet">
-<defs>
-    <style>
-        .k-nav { fill: #ffffff; }
-        .k-grn { fill: #33cc77; }
-        .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #ffffff; }
-        .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #ffffff; }
-    </style>
-</defs>
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
+
 <g  id="icon" transform="translate(0,6)">
     <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />
     <polygon points="60,8 104,8 60,52" class="k-grn" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-m-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-m-dark.svg
@@ -1,12 +1,18 @@
-﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="80" preserveAspectRatio="xMinYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="80" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #111111; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
         </style>
     </defs>
+
+    
+
+    
+    
 
     <g id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-m-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-m-light.svg
@@ -1,12 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="80" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #ffffff; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #ffffff; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #ffffff; }
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
         </style>
     </defs>
+
+    
+
+    
+    
     <g  id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />
         <polygon points="60,8 104,8 60,52" class="k-grn" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-s-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-s-dark.svg
@@ -1,12 +1,18 @@
-﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="60" preserveAspectRatio="xMinYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="60" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #111111; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
         </style>
     </defs>
+
+    
+
+    
+    
 
     <g id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-s-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-s-light.svg
@@ -1,12 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="60" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #ffffff; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #ffffff; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #ffffff; }
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
         </style>
     </defs>
+
+    
+
+    
+    
     <g  id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />
         <polygon points="60,8 104,8 60,52" class="k-grn" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xl-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xl-dark.svg
@@ -1,12 +1,18 @@
-﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="160" preserveAspectRatio="xMinYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="160" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #111111; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
         </style>
     </defs>
+
+    
+
+    
+    
 
     <g id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xl-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xl-light.svg
@@ -1,12 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="160" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #ffffff; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #ffffff; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #ffffff; }
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
         </style>
     </defs>
+
+    
+
+    
+    
     <g  id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />
         <polygon points="60,8 104,8 60,52" class="k-grn" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xs-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xs-dark.svg
@@ -1,12 +1,18 @@
-﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="40" preserveAspectRatio="xMinYMid meet">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="40" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #111111; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #111111; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #111111; }
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
         </style>
     </defs>
+
+    
+
+    
+    
 
     <g id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xs-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/horizontal/logo-horizontal-xs-light.svg
@@ -1,12 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 170" width="320" height="40" preserveAspectRatio="xMinYMid meet">
+
     <defs>
         <style>
-            .k-nav { fill: #ffffff; }
-            .k-grn { fill: #33cc77; }
-            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #ffffff; }
-            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #ffffff; }
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
         </style>
     </defs>
+
+    
+
+    
+    
     <g  id="icon" transform="translate(0,6)">
         <rect x="10" y="8" width="44" height="44" rx="6" class="k-nav" />
         <polygon points="60,8 104,8 60,52" class="k-grn" />

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-l-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-l-dark.svg
@@ -1,12 +1,25 @@
-﻿<svg width="120" height="180"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+<svg width="120" height="180"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-l-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-l-light.svg
@@ -1,11 +1,24 @@
 <svg width="120" height="180"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
             <rect id="svg_1" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="14" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,14 104,14 60,58 "/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,14 104,14 60,58 "/>
             <rect id="svg_3" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="64" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,64 104,64 104,108 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,64 104,64 104,108 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
             <rect id="svg_6" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="114" x="60"/>
         </g>
     </g>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-m-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-m-dark.svg
@@ -1,13 +1,26 @@
-﻿<svg width="120" height="120"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+<svg width="120" height="120"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
+        </style>
+    </defs>
+
+    
+
+    
 
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-m-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-m-light.svg
@@ -1,11 +1,24 @@
 <svg width="120" height="120"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
             <rect id="svg_1" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="14" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,14 104,14 60,58 "/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,14 104,14 60,58 "/>
             <rect id="svg_3" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="64" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,64 104,64 104,108 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,64 104,64 104,108 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
             <rect id="svg_6" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="114" x="60"/>
         </g>
     </g>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-s-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-s-dark.svg
@@ -1,13 +1,26 @@
-﻿<svg width="120" height="90"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+<svg width="120" height="90"  viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
+        </style>
+    </defs>
+
+    
+
+    
 
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-s-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-s-light.svg
@@ -1,11 +1,24 @@
 <svg width="120" height="90" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
             <rect id="svg_1" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="14" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,14 104,14 60,58 "/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,14 104,14 60,58 "/>
             <rect id="svg_3" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="64" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,64 104,64 104,108 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,64 104,64 104,108 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
             <rect id="svg_6" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="114" x="60"/>
         </g>
     </g>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xl-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xl-dark.svg
@@ -1,13 +1,26 @@
-﻿<svg width="120" height="240" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+<svg width="120" height="240" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
+        </style>
+    </defs>
+
+    
+
+    
 
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xl-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xl-light.svg
@@ -1,11 +1,24 @@
 <svg width="120" height="240" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
             <rect id="svg_1" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="14" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,14 104,14 60,58 "/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,14 104,14 60,58 "/>
             <rect id="svg_3" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="64" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,64 104,64 104,108 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,64 104,64 104,108 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
             <rect id="svg_6" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="114" x="60"/>
         </g>
     </g>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xs-dark.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xs-dark.svg
@@ -1,13 +1,26 @@
-﻿<svg width="120" height="60" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+<svg width="120" height="60" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #FFFFFF; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #FFFFFF; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #FFFFFF; }
+        </style>
+    </defs>
+
+    
+
+    
 
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xs-light.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/brand/logos/vertical/logo-vertical-xs-light.svg
@@ -1,11 +1,24 @@
 <svg width="120" height="60" viewBox="0 0 120 170" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMid meet">
+
+    <defs>
+        <style>
+            .k-nav { fill: #0F172A; }
+            .k-grn { fill: #764AF1; }
+            .brand { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 700; fill: #0F172A; }
+            .tag { font-family: 'Segoe UI', Roboto, Arial, sans-serif; font-weight: 600; fill: #0F172A; }
+        </style>
+    </defs>
+
+    
+
+    
     <g>
         <g id="icon">
             <rect id="svg_1" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="14" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,14 104,14 60,58 "/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,14 104,14 60,58 "/>
             <rect id="svg_3" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="64" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,64 104,64 104,108 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,64 104,64 104,108 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="114" x="10"/>
             <rect id="svg_6" fill="#ffffff" class="k-nav" rx="6" height="44" width="44" y="114" x="60"/>
         </g>
     </g>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/favicon.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/favicon.svg
@@ -2,12 +2,12 @@
 
     <g>
         <g id="icon">
-            <rect id="svg_1" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
-            <polygon id="svg_2" fill="#33cc77" class="k-grn" points="60,13 104,13 60,57 "/>
-            <rect id="svg_3" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
-            <polygon id="svg_4" fill="#33cc77" class="k-grn" points="60,63 104,63 104,107 "/>
-            <rect id="svg_5" fill="#33cc77" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
-            <rect id="svg_6" fill="#111111" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
+            <rect id="svg_1" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="13" x="10"/>
+            <polygon id="svg_2" fill="#764AF1" class="k-grn" points="60,13 104,13 60,57 "/>
+            <rect id="svg_3" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="63" x="10"/>
+            <polygon id="svg_4" fill="#764AF1" class="k-grn" points="60,63 104,63 104,107 "/>
+            <rect id="svg_5" fill="#764AF1" class="k-grn" rx="6" height="44" width="44" y="113" x="10"/>
+            <rect id="svg_6" fill="#0F172A" class="k-nav" rx="6" height="44" width="44" y="113" x="60"/>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
Refreshed Krafter's visual identity by updating all SVG assets and app.css to use a new deep tech purple (#764AF1) as the primary accent, replacing green. Added linear gradient and glow effects to key SVGs for a modern look. Introduced CSS custom properties for the new palette, covering primary, accent, background, surface, text, and status colors. Updated all color references in CSS and SVGs for consistency across themes. No functional changes; purely a visual/branding update.