### PR TITLE
Switch menu icons to Material Design, remove SVGs

### DIFF
--- a/src/UI/Krafter.UI.Web.Client/Common/Components/Layout/NavigationItem.razor
+++ b/src/UI/Krafter.UI.Web.Client/Common/Components/Layout/NavigationItem.razor
@@ -1,12 +1,6 @@
 ﻿@if (!Example.New && !Example.Updated)
 {
-    <RadzenPanelMenuItem @bind-Expanded=@Expanded Text="@Example.Name" Path="@GetUrl()" aria-label="@Example.Name">
-
-        <Template>
-            <img src="@($"svg/icons/{Example.Icon}.svg")"/>
-            @Example.Name
-        </Template>
-
+    <RadzenPanelMenuItem @bind-Expanded=@Expanded Text="@Example.Name" Path="@GetUrl()" Icon="@Example.Icon" aria-label="@Example.Name">
         <ChildContent>@ChildContent</ChildContent>
     </RadzenPanelMenuItem>
 }

--- a/src/UI/Krafter.UI.Web.Client/Infrastructure/Services/MenuService.cs
+++ b/src/UI/Krafter.UI.Web.Client/Infrastructure/Services/MenuService.cs
@@ -1,4 +1,4 @@
-﻿using Krafter.Shared.Common.Auth.Permissions;
+using Krafter.Shared.Common.Auth.Permissions;
 using Krafter.UI.Web.Client.Common.Constants;
 using Krafter.UI.Web.Client.Models;
 
@@ -12,7 +12,7 @@ public class MenuService
         {
             Name = "Home",
             Path = "/",
-            Icon = "course-icon-static",
+            Icon = "home",
             Title = "Manage Courses",
             Description =
                 "Manage courses, including creation, updates, and access control for course listings.",
@@ -21,7 +21,7 @@ public class MenuService
         new Menu
         {
             Name = "Account",
-            Icon = "account-icon-static",
+            Icon = "account_circle",
             Children = new[]
             {
                 new Menu
@@ -30,7 +30,7 @@ public class MenuService
                     Path = KrafterRoute.Users,
                     Title = "User Management",
                     Description = "Manage user accounts, including creation, updates, and access control.",
-                    Icon = "user-icon-static",
+                    Icon = "people",
                     Tags = new[] { "users", "accounts", "profiles", "authentication" },
                     Permission = KrafterPermission.NameFor(KrafterAction.View, KrafterResource.Users)
                 },
@@ -40,7 +40,7 @@ public class MenuService
                     Path = KrafterRoute.Roles,
                     Title = "Role Management",
                     Description = "Manage user roles and associated permissions within the system.",
-                    Icon = "role-icon-static",
+                    Icon = "admin_panel_settings",
                     Tags = new[] { "roles", "permissions", "access control", "user groups" },
                     Permission = KrafterPermission.NameFor(KrafterAction.View, KrafterResource.Roles)
                 }
@@ -50,7 +50,7 @@ public class MenuService
         {
             Name = "Tenants",
             Path = KrafterRoute.Tenants,
-            Icon = "tenant-icon-static",
+            Icon = "business",
             Permission = KrafterPermission.NameFor(KrafterAction.View, KrafterResource.Tenants),
             Title = "Tenant Management",
             Description = "Manage multiple tenants within the system, including creation and updates.",

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/account-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/account-icon-static.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<circle cx="8" cy="4" r="2.5" fill="#009688" />
-	<rect x="3" y="7" width="10" height="6" fill="#009688" rx="1" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/chapters-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/chapters-icon-static.svg
@@ -1,6 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<rect x="3" y="3" width="10" height="2" fill="#009688" rx="0.5" />
-	<rect x="3" y="7" width="10" height="2" fill="#009688" rx="0.5" />
-	<rect x="3" y="11" width="10" height="2" fill="#009688" rx="0.5" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/content-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/content-icon-static.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<path d="M2 2 L14 2 L14 14 L2 14 Z" fill="none" stroke="#009688" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/course-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/course-icon-static.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<circle cx="8" cy="8" r="5" fill="none" stroke="#009688" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/course-icon-static_96x96.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/course-icon-static_96x96.svg
@@ -1,4 +1,0 @@
-<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
-    <rect width="16" height="16" fill="transparent" />
-    <path d="M2 2 L6 2 L6 6 L2 6 Z M10 2 L14 2 L14 6 L10 6 Z M2 10 L6 10 L6 14 L2 14 Z M10 10 L14 10 L14 14 L10 14 Z" fill="#009688" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/dashboard-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/dashboard-icon-static.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<path d="M2 2 L6 2 L6 6 L2 6 Z M10 2 L14 2 L14 6 L10 6 Z M2 10 L6 10 L6 14 L2 14 Z M10 10 L14 10 L14 14 L10 14 Z" fill="#009688" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/media-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/media-icon-static.svg
@@ -1,6 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<rect x="3.2" y="3.2" width="9.6" height="9.6" fill="none" stroke="#009688" stroke-width="0.64" stroke-linecap="round" stroke-linejoin="round" />
-	<line x1="4.8" y1="6.4" x2="11.2" y2="6.4" stroke="#1DB954" stroke-width="0.64" stroke-linecap="round" />
-	<line x1="4.8" y1="9.6" x2="11.2" y2="9.6" stroke="#1DB954" stroke-width="0.64" stroke-linecap="round" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/push-message-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/push-message-icon-static.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<path d="M8 0L0 8H5V16H11V8H16L8 0Z" fill="#009688" />
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/role-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/role-icon-static.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<path d="M8,1 L14,5 L14,11 L8,15 L2,11 L2,5 L8,1 Z" fill="none" stroke="#009688" stroke-width="1.5" stroke-linejoin="round"/>
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/tenant-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/tenant-icon-static.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<rect x="2" y="3" width="12" height="5" fill="#009688" rx="1"/>
-	<rect x="2" y="9" width="12" height="3" fill="#1DB954" rx="1"/>
-</svg>

--- a/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/user-icon-static.svg
+++ b/src/UI/Krafter.UI.Web.Client/wwwroot/svg/icons/user-icon-static.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-	<rect width="16" height="16" fill="transparent" />
-	<circle cx="8" cy="4" r="3" fill="#009688" />
-	<path d="M3 11 A5 5 0 0 1 13 11" stroke="#009688" stroke-width="2" stroke-linecap="round" fill="none" />
-</svg>


### PR DESCRIPTION
Updated navigation to use Material Design icon names via RadzenPanelMenuItem's Icon property. Removed all custom static SVG icon files for menu items to improve consistency and simplify icon management.