### PR TITLE
Refactor to use Response factory methods for errors/success

### DIFF
--- a/src/Backend/Common/Interfaces/Multitenancy.cs
+++ b/src/Backend/Common/Interfaces/Multitenancy.cs
@@ -5,7 +5,7 @@ namespace Backend.Common.Interfaces;
 
 public interface ITenantFinderService
 {
-    public Task<Tenant> Find(string? identifier);
+    public Task<Response<Tenant>> Find(string? identifier);
 }
 
 public interface ITenantGetterService

--- a/src/Backend/Features/Auth/_Shared/ITokenService.cs
+++ b/src/Backend/Features/Auth/_Shared/ITokenService.cs
@@ -1,10 +1,11 @@
 using Backend.Features.Users._Shared;
+using Krafter.Shared.Common.Models;
 using Krafter.Shared.Contracts.Auth;
 
 namespace Backend.Features.Auth._Shared;
 
 public interface ITokenService
 {
-    public Task<TokenResponse> GenerateTokensAndUpdateUser(string userId, string ipAddress);
+    public Task<Response<TokenResponse>> GenerateTokensAndUpdateUser(string userId, string ipAddress);
     public Task<TokenResponse> GenerateTokensAndUpdateUser(KrafterUser user, string ipAddress);
 }

--- a/src/Backend/Features/Auth/_Shared/TokenService.cs
+++ b/src/Backend/Features/Auth/_Shared/TokenService.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Backend.Api.Configuration;
-using Backend.Application.Common;
 using Backend.Features.Users._Shared;
 using Backend.Infrastructure.Persistence;
 using Krafter.Shared.Common.Auth;
@@ -28,15 +27,15 @@ public class TokenService(
     private readonly JwtSettings _jwtSettings = jwtSettings.Value;
 
 
-    public async Task<TokenResponse> GenerateTokensAndUpdateUser(string userId, string ipAddress)
+    public async Task<Response<TokenResponse>> GenerateTokensAndUpdateUser(string userId, string ipAddress)
     {
         KrafterUser? user = await userManager.FindByIdAsync(userId);
         if (user is null)
         {
-            throw new UnauthorizedException("Authentication Failed.");
+            return Response<TokenResponse>.Unauthorized("Authentication Failed.");
         }
 
-        return await GenerateTokensAndUpdateUser(user, ipAddress);
+        return Response<TokenResponse>.Success(await GenerateTokensAndUpdateUser(user, ipAddress));
     }
 
     public async Task<TokenResponse> GenerateTokensAndUpdateUser(KrafterUser user, string ipAddress)

--- a/src/Backend/Features/Roles/CreateOrUpdateRole.cs
+++ b/src/Backend/Features/Roles/CreateOrUpdateRole.cs
@@ -1,6 +1,5 @@
 using Backend.Api;
 using Backend.Api.Authorization;
-using Backend.Application.Common;
 using Backend.Common.Interfaces;
 using Backend.Features.Roles._Shared;
 using Backend.Features.Users._Shared;
@@ -35,7 +34,7 @@ public sealed class CreateOrUpdateRole
                 IdentityResult result = await roleManager.CreateAsync(role);
                 if (!result.Succeeded)
                 {
-                    throw new KrafterException($"Register role failed {result.Errors.ToString()}");
+                    return Response.BadRequest($"Register role failed {result.Errors.ToString()}");
                 }
             }
             else
@@ -43,14 +42,14 @@ public sealed class CreateOrUpdateRole
                 role = await roleManager.FindByIdAsync(request.Id);
                 if (role == null)
                 {
-                    throw new NotFoundException("Role Not Found");
+                    return Response.NotFound("Role Not Found");
                 }
 
                 if (request.Name != role.Name)
                 {
                     if (KrafterRoleConstant.IsDefault(role.Name!))
                     {
-                        throw new ForbiddenException($"Not allowed to modify {role.Name} Role.");
+                        return Response.Forbidden($"Not allowed to modify {role.Name} Role.");
                     }
 
                     role.Name = request.Name;
@@ -61,7 +60,7 @@ public sealed class CreateOrUpdateRole
                 {
                     if (KrafterRoleConstant.IsDefault(role.Name!))
                     {
-                        throw new ForbiddenException($"Not allowed to modify {role.Name} Role.");
+                        return Response.Forbidden($"Not allowed to modify {role.Name} Role.");
                     }
 
                     role.Description = request.Description;
@@ -70,7 +69,7 @@ public sealed class CreateOrUpdateRole
                 IdentityResult result = await roleManager.UpdateAsync(role);
                 if (!result.Succeeded)
                 {
-                    throw new KrafterException($"Update role failed {result.Errors.ToString()}");
+                    return Response.BadRequest($"Update role failed {result.Errors.ToString()}");
                 }
             }
 
@@ -78,7 +77,7 @@ public sealed class CreateOrUpdateRole
             {
                 if (role.Name == KrafterRoleConstant.Admin)
                 {
-                    throw new KrafterException("Not allowed to modify Permissions for this Role.");
+                    return Response.BadRequest("Not allowed to modify Permissions for this Role.");
                 }
 
                 List<KrafterRoleClaim> permissions = await db.RoleClaims

--- a/src/Backend/Features/Roles/DeleteRole.cs
+++ b/src/Backend/Features/Roles/DeleteRole.cs
@@ -1,6 +1,5 @@
 using Backend.Api;
 using Backend.Api.Authorization;
-using Backend.Application.Common;
 using Backend.Common.Interfaces;
 using Backend.Features.Roles._Shared;
 using Backend.Features.Users._Shared;
@@ -28,11 +27,14 @@ public sealed class DeleteRole
         {
             KrafterRole? role = await roleManager.FindByIdAsync(requestInput.Id);
 
-            _ = role ?? throw new NotFoundException("Role Not Found");
+            if (role is null)
+            {
+                return Response.NotFound("Role Not Found");
+            }
 
             if (KrafterRoleConstant.IsDefault(role.Name!))
             {
-                throw new ForbiddenException($"Not allowed to delete {role.Name} Role.");
+                return Response.Forbidden($"Not allowed to delete {role.Name} Role.");
             }
 
             role.IsDeleted = true;

--- a/src/Backend/Features/Roles/_Shared/RoleService.cs
+++ b/src/Backend/Features/Roles/_Shared/RoleService.cs
@@ -1,4 +1,3 @@
-using Backend.Application.Common;
 using Backend.Common.Interfaces;
 using Backend.Features.Users._Shared;
 using Backend.Infrastructure.Persistence;
@@ -22,9 +21,9 @@ public class RoleService(
         KrafterRole? res = await db.Roles.SingleOrDefaultAsync(x => x.Id == id);
         if (res is not null)
         {
-            return new Response<RoleDto> { Data = res.Adapt<RoleDto>() };
+            return Response<RoleDto>.Success(res.Adapt<RoleDto>());
         }
 
-        throw new NotFoundException("Role Not Found");
+        return Response<RoleDto>.NotFound("Role Not Found");
     }
 }

--- a/src/Backend/Features/Tenants/CreateOrUpdate.cs
+++ b/src/Backend/Features/Tenants/CreateOrUpdate.cs
@@ -1,6 +1,5 @@
 using Backend.Api;
 using Backend.Api.Authorization;
-using Backend.Application.Common;
 using Backend.Common.Interfaces;
 using Backend.Common.Interfaces.Auth;
 using Backend.Features.Tenants._Shared;
@@ -81,7 +80,7 @@ public sealed class CreateOrUpdate
                 Tenant? tenant = await dbContext.Tenants.FirstOrDefaultAsync(c => c.Id == request.Id);
                 if (tenant is null)
                 {
-                    throw new KrafterException(
+                    return Response.BadRequest(
                         "Unable to find tenant, please try again later or contact support.");
                 }
 

--- a/src/Backend/Features/Tenants/Delete.cs
+++ b/src/Backend/Features/Tenants/Delete.cs
@@ -1,6 +1,5 @@
 using Backend.Api;
 using Backend.Api.Authorization;
-using Backend.Application.Common;
 using Backend.Common;
 using Backend.Features.Tenants._Shared;
 using Backend.Features.Users._Shared;
@@ -22,13 +21,13 @@ public sealed class Delete
             Tenant? tenant = await dbContext.Tenants.AsNoTracking().FirstOrDefaultAsync(c => c.Id == requestInput.Id);
             if (tenant is null)
             {
-                throw new KrafterException(
+                return Response.BadRequest(
                     "Unable to find tenant, please try again later or contact support.");
             }
 
             if (tenant.Id == KrafterInitialConstants.RootTenant.Id)
             {
-                throw new ForbiddenException(
+                return Response.Forbidden(
                     "You cannot delete the root tenant.");
             }
 

--- a/src/Backend/Infrastructure/Persistence/Tenants/TenantFinderService.cs
+++ b/src/Backend/Infrastructure/Persistence/Tenants/TenantFinderService.cs
@@ -1,37 +1,37 @@
-using Backend.Application.Common;
 using Backend.Common.Interfaces;
 using Backend.Features.Tenants._Shared;
 using Backend.Features.Users._Shared;
+using Krafter.Shared.Common.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Infrastructure.Persistence.Tenants;
 
 public class TenantFinderService(TenantDbContext tenantDbContext) : ITenantFinderService
 {
-    public async Task<Tenant> Find(string? identifier)
+    public async Task<Response<Tenant>> Find(string? identifier)
     {
         if (string.IsNullOrWhiteSpace(identifier))
         {
-            return KrafterInitialConstants.KrafterTenant;
+            return Response<Tenant>.Success(KrafterInitialConstants.KrafterTenant);
         }
 
         Tenant? tenant = await tenantDbContext.Tenants.AsNoTracking()
             .SingleOrDefaultAsync(c => c.Identifier == identifier);
         if (tenant is null)
         {
-            return KrafterInitialConstants.KrafterTenant;
+            return Response<Tenant>.Success(KrafterInitialConstants.KrafterTenant);
         }
 
         if (tenant.IsActive == false)
         {
-            throw new KrafterException("Tenant is not active");
+            return Response<Tenant>.BadRequest("Tenant is not active");
         }
 
         if (tenant.ValidUpto < DateTime.UtcNow)
         {
-            throw new KrafterException("Tenant validity expired");
+            return Response<Tenant>.BadRequest("Tenant validity expired");
         }
 
-        return tenant;
+        return Response<Tenant>.Success(tenant);
     }
 }

--- a/src/Krafter.Shared/Agents.md
+++ b/src/Krafter.Shared/Agents.md
@@ -188,7 +188,58 @@ public static class ProductCategoryConstant
 | Constant class | `<Entity>Constant` | `KrafterRoleConstant` |
 | Namespace | `Krafter.Shared.Contracts.<Feature>` | `Krafter.Shared.Contracts.Users` |
 
-## 6. Rules
+## 6. Response Class Factory Methods
+
+The `Response` and `Response<T>` classes in `Common/Models/Response.cs` provide static factory methods for creating responses.
+
+### 6.1 Error Factory Methods
+
+```csharp
+// Non-generic Response
+Response.NotFound("Resource not found");      // 404
+Response.BadRequest("Invalid input");         // 400
+Response.Unauthorized("Invalid credentials"); // 401
+Response.Forbidden("Access denied");          // 403
+Response.Conflict("Resource already exists"); // 409
+Response.CustomError("Custom error", 422);    // Custom status code
+
+// Generic Response<T>
+Response<UserDto>.NotFound("User not found");
+Response<UserDto>.BadRequest("Invalid input");
+Response<UserDto>.Unauthorized("Invalid credentials");
+Response<UserDto>.Forbidden("Access denied");
+Response<UserDto>.Conflict("User already exists");
+Response<UserDto>.CustomError("Custom error", 422);
+```
+
+### 6.2 Success Factory Methods
+
+```csharp
+// Non-generic Response
+Response.Success();                           // 200, no message
+Response.Success("Operation completed");      // 200, with message
+
+// Generic Response<T>
+Response<UserDto>.Success(userDto);           // 200, with data
+Response<UserDto>.Success(userDto, "User created"); // 200, with data and message
+```
+
+### 6.3 Factory Method Behavior
+
+All error factory methods:
+- Set `IsError = true`
+- Set `StatusCode` to the appropriate HTTP status code
+- Set `Message` to the provided message
+- Set `Error.Message` to the provided message
+- For `Response<T>`, set `Data = default`
+
+All success factory methods:
+- Set `IsError = false`
+- Set `StatusCode = 200`
+- Set `Message` to the provided message (optional)
+- For `Response<T>`, set `Data` to the provided data
+
+## 7. Rules
 
 ### DO:
 - ✅ Include XML documentation on all public classes
@@ -203,7 +254,7 @@ public static class ProductCategoryConstant
 - ❌ Add Entity Framework attributes (those belong in Backend)
 - ❌ Create nested classes for DTOs - use flat structure
 
-## 7. New Contract Checklist
+## 8. New Contract Checklist
 
 1. [ ] Create file in `Contracts/<Feature>/`
 2. [ ] Add namespace `Krafter.Shared.Contracts.<Feature>`
@@ -213,9 +264,9 @@ public static class ProductCategoryConstant
 6. [ ] Build to verify: `dotnet build src/Krafter.Shared/Krafter.Shared.csproj`
 7. [ ] Update Backend imports from `Krafter.Shared.Contracts.<Feature>`
 
-## 8. Edge Cases: Adding New Feature Support
+## 9. Edge Cases: Adding New Feature Support
 
-### 8.1 Add EntityKind for Delete Operations
+### 9.1 Add EntityKind for Delete Operations
 When adding a new feature that supports soft-delete, add to `Common/Enums/EntityKind.cs`:
 
 ```csharp
@@ -242,7 +293,7 @@ public enum EntityKind
 - 300-399: Commerce entities (Cart, Order, Payment)
 - 400+: New feature entities
 
-### 8.2 Add Permissions for New Feature
+### 9.2 Add Permissions for New Feature
 Add to `Common/Auth/Permissions/`:
 
 **Step 1: Add Resource** (`KrafterResource.cs`):
@@ -278,7 +329,7 @@ private static readonly KrafterPermission[] AllPermissions =
 - `IsRoot = true`: Only available to root/super admin (like Tenant management)
 - Default (no flags): Available to Admin role
 
-### 8.3 Add API Route Constant
+### 9.3 Add API Route Constant
 Add to `Common/KrafterRoute.cs`:
 
 ```csharp
@@ -293,5 +344,5 @@ public static class KrafterRoute
 
 ---
 Last Updated: 2025-12-31
-Verified Against: Contracts/Users/CreateUserRequest.cs, Contracts/Users/UserDto.cs, Common/Models/CommonDtoProperty.cs, Common/Enums/EntityKind.cs, Common/Auth/Permissions/KrafterPermissions.cs, Common/KrafterRoute.cs
+Verified Against: Contracts/Users/CreateUserRequest.cs, Contracts/Users/UserDto.cs, Common/Models/CommonDtoProperty.cs, Common/Models/Response.cs, Common/Enums/EntityKind.cs, Common/Auth/Permissions/KrafterPermissions.cs, Common/KrafterRoute.cs
 ---

--- a/src/Krafter.Shared/Common/Models/Response.cs
+++ b/src/Krafter.Shared/Common/Models/Response.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 
 namespace Krafter.Shared.Common.Models;
 
@@ -9,6 +9,31 @@ public class Response<T>
     public T? Data { get; set; }
     public string? Message { get; set; }
     public ErrorResult Error { get; set; } = new();
+
+    // Factory methods for error responses
+    public static Response<T> NotFound(string message) => CreateError(message, HttpStatusCode.NotFound);
+    public static Response<T> Conflict(string message) => CreateError(message, HttpStatusCode.Conflict);
+    public static Response<T> Forbidden(string message) => CreateError(message, HttpStatusCode.Forbidden);
+    public static Response<T> Unauthorized(string message) => CreateError(message, HttpStatusCode.Unauthorized);
+    public static Response<T> BadRequest(string message) => CreateError(message, HttpStatusCode.BadRequest);
+
+    public static Response<T> CustomError(string message, int statusCode) =>
+        CreateError(message, (HttpStatusCode)statusCode);
+
+    // Factory method for success response
+    public static Response<T> Success(T data, string? message = null) => new()
+    {
+        IsError = false, StatusCode = (int)HttpStatusCode.OK, Data = data, Message = message
+    };
+
+    private static Response<T> CreateError(string message, HttpStatusCode statusCode) => new()
+    {
+        IsError = true,
+        StatusCode = (int)statusCode,
+        Message = message,
+        Error = new ErrorResult { Message = message },
+        Data = default
+    };
 }
 
 public class Response
@@ -17,6 +42,30 @@ public class Response
     public int StatusCode { get; set; } = (int)HttpStatusCode.OK;
     public string? Message { get; set; }
     public ErrorResult Error { get; set; } = new();
+
+    // Factory methods for error responses
+    public static Response NotFound(string message) => CreateError(message, HttpStatusCode.NotFound);
+    public static Response Conflict(string message) => CreateError(message, HttpStatusCode.Conflict);
+    public static Response Forbidden(string message) => CreateError(message, HttpStatusCode.Forbidden);
+    public static Response Unauthorized(string message) => CreateError(message, HttpStatusCode.Unauthorized);
+    public static Response BadRequest(string message) => CreateError(message, HttpStatusCode.BadRequest);
+
+    public static Response CustomError(string message, int statusCode) =>
+        CreateError(message, (HttpStatusCode)statusCode);
+
+    // Factory method for success response
+    public static Response Success(string? message = null) => new()
+    {
+        IsError = false, StatusCode = (int)HttpStatusCode.OK, Message = message
+    };
+
+    private static Response CreateError(string message, HttpStatusCode statusCode) => new()
+    {
+        IsError = true,
+        StatusCode = (int)statusCode,
+        Message = message,
+        Error = new ErrorResult { Message = message }
+    };
 }
 
 public class ErrorResult


### PR DESCRIPTION
Standardize backend error/success handling using new static factory methods on Response and Response<T>. Refactor feature handlers, services, and SignalR hubs to return Response objects instead of throwing exceptions or manually constructing responses. Update documentation to recommend factory methods and clarify exception usage. Improves consistency, API clarity, and client-side error handling.